### PR TITLE
Fix Bug on Array Parameter

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -293,7 +293,7 @@ CAstExpression* CParser::parameter(CAstScope* s)
   CAstExpression* arg = expression(s);
   CAstDesignator* dsn = dynamic_cast<CAstDesignator*>(arg);
   if (dsn != NULL) {
-    if(dsn->GetSymbol()->GetDataType()->IsArray()) {
+    if(dsn->GetType()->IsArray()) {
       CToken defaultToken;
       return new CAstSpecialOp(defaultToken, opAddress, arg);
     }


### PR DESCRIPTION
레퍼런스로 실험 해보니, 레퍼런스에서 &()를 쓰는 경우는 
타입이 array이면서 function의 parameter 타입이 array 일 때이다.

물론 그렇게 만들 수는 있지만, 현재 코드에서 조금 짜기 편하도록, 
타입이 array일 때, 무조건 &()를 썼다.

이것이 문제가 되지 않는 이유는 파라미터에 포인터 타입이 들어갈 경우는 파라미터 타입이 array 일 때 뿐이기 때문에, 타입 체킹을 할 때, 문제가 되지 않을 것이기 때문이다. 
